### PR TITLE
Module name changed to sigs.k8s.io/ibm-powervs-block-csi-driver

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Build
       run: |
         mkdir -p bin
-        make bin/powervs-csi-driver
+        make bin/ibm-powervs-block-csi-driver

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
 #FROM golang:1.15-buster AS builder
-#WORKDIR /go/src/github.com/ppc64le-cloud/powervs-csi-driver
+#WORKDIR /go/src/sigs.k8s.io/ibm-powervs-block-csi-driver
 #COPY . .
 #RUN make
 
 FROM --platform=linux/ppc64le k8s.gcr.io/build-image/debian-base:v2.1.3 AS debian-base
 RUN clean-install ca-certificates e2fsprogs mount udev util-linux xfsprogs
 RUN clean-install bash multipath-tools sg3-utils
-# COPY --from=builder /go/src/github.com/ppc64le-cloud/powervs-csi-driver/bin/powervs-csi-driver /bin/powervs-csi-driver
-COPY ./bin/powervs-csi-driver /bin/powervs-csi-driver
+# COPY --from=builder /go/src/sigs.k8s.io/ibm-powervs-block-csi-driver/bin/ibm-powervs-block-csi-driver /bin/ibm-powervs-block-csi-driver
+COPY ./bin/ibm-powervs-block-csi-driver /bin/ibm-powervs-block-csi-driver
 
-ENTRYPOINT ["/bin/powervs-csi-driver"]
+ENTRYPOINT ["/bin/ibm-powervs-block-csi-driver"]
 
 FROM --platform=linux/ppc64le registry.access.redhat.com/ubi8/ubi:8.5 AS rhel-base
 RUN yum --disableplugin=subscription-manager -y install httpd php \
   && yum --disableplugin=subscription-manager clean all
 RUN clean-install ca-certificates e2fsprogs mount udev util-linux xfsprogs
-# COPY --from=builder /go/src/github.com/ppc64le-cloud/powervs-csi-driver/bin/powervs-csi-driver /bin/powervs-csi-driver
-COPY ./bin/powervs-csi-driver /bin/powervs-csi-driver
+# COPY --from=builder /go/src/sigs.k8s.io/ibm-powervs-block-csi-driver/bin/ibm-powervs-block-csi-driver /bin/ibm-powervs-block-csi-driver
+COPY ./bin/ibm-powervs-block-csi-driver /bin/ibm-powervs-block-csi-driver
 
-ENTRYPOINT ["/bin/powervs-csi-driver"]
+ENTRYPOINT ["/bin/ibm-powervs-block-csi-driver"]

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PKG=github.com/ppc64le-cloud/powervs-csi-driver
-IMAGE?=quay.io/powercloud/powervs-csi-driver
+PKG=sigs.k8s.io/ibm-powervs-block-csi-driver
+IMAGE?=quay.io/powercloud/ibm-powervs-block-csi-driver
 VERSION=v0.0.1
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -27,9 +27,9 @@ PLATFORM=linux/ppc64le
 
 .EXPORT_ALL_VARIABLES:
 
-.PHONY: bin/powervs-csi-driver
-bin/powervs-csi-driver: | bin
-	CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -ldflags ${LDFLAGS} -o bin/powervs-csi-driver ./cmd/
+.PHONY: bin/ibm-powervs-block-csi-driver
+bin/ibm-powervs-block-csi-driver: | bin
+	CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -ldflags ${LDFLAGS} -o bin/ibm-powervs-block-csi-driver ./cmd/
 
 .PHONY: test
 test:
@@ -41,7 +41,7 @@ image-release:
 
 .PHONY: image
 image:
-	docker build -t $(IMAGE):latest . --target debian-base
+	docker build -t $(IMAGE):$(VERSION) . --target debian-base
 
 .PHONY: push-release
 push-release:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# powervs-csi-driver
+# ibm-powervs-block-csi-driver
 CSI Driver for IBM® Power Systems™ Virtual Server

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,13 +21,13 @@ package main
 import (
 	"flag"
 
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/driver"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/driver"
 
 	"k8s.io/klog/v2"
 )
 
 func main() {
-	fs := flag.NewFlagSet("powervs-csi-driver", flag.ExitOnError)
+	fs := flag.NewFlagSet("ibm-powervs-block-csi-driver", flag.ExitOnError)
 	options := GetOptions(fs)
 
 	drv, err := driver.NewDriver(

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -23,8 +23,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ppc64le-cloud/powervs-csi-driver/cmd/options"
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/driver"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/cmd/options"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/driver"
 
 	"k8s.io/klog/v2"
 )

--- a/cmd/options/server_options.go
+++ b/cmd/options/server_options.go
@@ -21,7 +21,7 @@ package options
 import (
 	"flag"
 
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/driver"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/driver"
 )
 
 // ServerOptions contains options and configuration settings for the driver server.

--- a/deploy/kubernetes/base/clusterrole-attacher.yaml
+++ b/deploy/kubernetes/base/clusterrole-attacher.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: powervs-external-attacher-role
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/deploy/kubernetes/base/clusterrole-csi-node.yaml
+++ b/deploy/kubernetes/base/clusterrole-csi-node.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: powervs-node-role
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 rules:
   - apiGroups: [""]
     resources: ["nodes"]

--- a/deploy/kubernetes/base/clusterrole-provisioner.yaml
+++ b/deploy/kubernetes/base/clusterrole-provisioner.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: powervs-external-provisioner-role
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/deploy/kubernetes/base/clusterrole-resizer.yaml
+++ b/deploy/kubernetes/base/clusterrole-resizer.yaml
@@ -4,7 +4,7 @@
  metadata:
    name: powervs-external-resizer-role
    labels:
-     app.kubernetes.io/name: powervs-csi-driver
+     app.kubernetes.io/name: ibm-powervs-block-csi-driver
  rules:
    # The following rule should be uncommented for plugins that require secrets
    # for provisioning.

--- a/deploy/kubernetes/base/clusterrolebinding-attacher.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-attacher.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: powervs-csi-attacher-binding
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 subjects:
   - kind: ServiceAccount
     name: powervs-csi-controller-sa

--- a/deploy/kubernetes/base/clusterrolebinding-csi-node.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-csi-node.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: powervs-csi-node-getter-binding
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 subjects:
   - kind: ServiceAccount
     name: powervs-csi-node-sa

--- a/deploy/kubernetes/base/clusterrolebinding-provisioner.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-provisioner.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: powervs-csi-provisioner-binding
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 subjects:
   - kind: ServiceAccount
     name: powervs-csi-controller-sa

--- a/deploy/kubernetes/base/clusterrolebinding-resizer.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-resizer.yaml
@@ -4,7 +4,7 @@
  metadata:
    name: powervs-csi-resizer-binding
    labels:
-     app.kubernetes.io/name: powervs-csi-driver
+     app.kubernetes.io/name: ibm-powervs-block-csi-driver
  subjects:
    - kind: ServiceAccount
      name: powervs-csi-controller-sa

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -5,18 +5,18 @@ metadata:
   name: powervs-csi-controller
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: powervs-csi-controller
-      app.kubernetes.io/name: powervs-csi-driver
+      app.kubernetes.io/name: ibm-powervs-block-csi-driver
   template:
     metadata:
       labels:
         app: powervs-csi-controller
-        app.kubernetes.io/name: powervs-csi-driver
+        app.kubernetes.io/name: ibm-powervs-block-csi-driver
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -26,7 +26,7 @@ spec:
         - operator: Exists
       containers:
         - name: powervs-plugin
-          image: quay.io/powercloud/powervs-csi-driver:v0.0.1
+          image: quay.io/powercloud/ibm-powervs-block-csi-driver:v0.0.1
           imagePullPolicy: Always
           args:
             # - {all,controller,node} # specify the driver mode

--- a/deploy/kubernetes/base/csidriver.yaml
+++ b/deploy/kubernetes/base/csidriver.yaml
@@ -4,7 +4,7 @@ kind: CSIDriver
 metadata:
   name: powervs.csi.ibm.com
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 spec:
   attachRequired: true
   podInfoOnMount: false

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -5,17 +5,17 @@ metadata:
   name: powervs-csi-node
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 spec:
   selector:
     matchLabels:
       app: powervs-csi-node
-      app.kubernetes.io/name: powervs-csi-driver
+      app.kubernetes.io/name: ibm-powervs-block-csi-driver
   template:
     metadata:
       labels:
         app: powervs-csi-node
-        app.kubernetes.io/name: powervs-csi-driver
+        app.kubernetes.io/name: ibm-powervs-block-csi-driver
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -28,7 +28,7 @@ spec:
         - name: powervs-plugin
           securityContext:
             privileged: true
-          image: quay.io/powercloud/powervs-csi-driver:v0.0.1
+          image: quay.io/powercloud/ibm-powervs-block-csi-driver:v0.0.1
           imagePullPolicy: Always
           args:
             - node

--- a/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
+++ b/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
@@ -5,4 +5,4 @@ metadata:
   name: powervs-csi-controller-sa
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver

--- a/deploy/kubernetes/base/serviceaccount-csi-node.yaml
+++ b/deploy/kubernetes/base/serviceaccount-csi-node.yaml
@@ -5,4 +5,4 @@ metadata:
   name: powervs-csi-node-sa
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver

--- a/deploy/kubernetes/overlays/dev/main_image.yaml
+++ b/deploy/kubernetes/overlays/dev/main_image.yaml
@@ -4,13 +4,13 @@ metadata:
   name: powervs-csi-node
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 spec:
   template:
     spec:
       containers:
         - name: powervs-plugin
-          image: quay.io/powercloud/powervs-csi-driver:dev
+          image: quay.io/powercloud/ibm-powervs-block-csi-driver:dev
           imagePullPolicy: Always
 ---
 kind: Deployment
@@ -19,11 +19,11 @@ metadata:
   name: powervs-csi-controller
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: powervs-csi-driver
+    app.kubernetes.io/name: ibm-powervs-block-csi-driver
 spec:
   template:
     spec:
       containers:
         - name: powervs-plugin
-          image: quay.io/powercloud/powervs-csi-driver:dev
+          image: quay.io/powercloud/ibm-powervs-block-csi-driver:dev
           imagePullPolicy: Always

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 bases:
   - ../../base
 images:
-  - name: quay.io/powercloud/powervs-csi-driver
+  - name: quay.io/powercloud/ibm-powervs-block-csi-driver
     newTag: v0.0.1
   - name: k8s.gcr.io/sig-storage/csi-provisioner
     newTag: v3.0.0

--- a/examples/kubernetes/dynamic-provisioning/Readme.md
+++ b/examples/kubernetes/dynamic-provisioning/Readme.md
@@ -5,7 +5,7 @@ This example shows how to create a PowerVS volume and consume it from container 
 
 1. Kubernetes 1.13+ (CSI 1.0).
 
-2. The [powervs-ebs-csi-driver](https://github.com/ppc64le-cloud/powervs-csi-driver) is installed.
+2. The [powervs-ebs-csi-driver](https://sigs.k8s.io/ibm-powervs-block-csi-driver) is installed.
 
 ## Usage
 

--- a/examples/kubernetes/storageclass/Readme.md
+++ b/examples/kubernetes/storageclass/Readme.md
@@ -1,5 +1,5 @@
 # Configuring StorageClass
-This example shows how to configure Kubernetes storageclass to provision PowerVS volumes with various configuration parameters. PowerVS CSI driver is compatiable with in-tree PowerVS plugin on StorageClass parameters. 
+This example shows how to configure Kubernetes storageclass to provision PowerVS volumes with various configuration parameters. IBM PowerVS Block CSI Driver is compatiable with in-tree PowerVS plugin on StorageClass parameters. 
 
 ## Usage
 1. Edit the StorageClass spec in [example manifest](./specs/example.yaml) and update storageclass parameters to desired value. In this example, a `tier1` PowerVS volume will be created and formatted to `xfs` filesystem.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ppc64le-cloud/powervs-csi-driver
+module sigs.k8s.io/ibm-powervs-block-csi-driver
 
 go 1.17
 

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -19,7 +19,7 @@ package cloud
 import (
 	"errors"
 
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/util"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/util"
 )
 
 // PowerVS volume types

--- a/pkg/cloud/powervs.go
+++ b/pkg/cloud/powervs.go
@@ -36,9 +36,9 @@ import (
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang-jwt/jwt"
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/util"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/util"
 )
 
 var _ Cloud = &powerVSCloud{}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -21,11 +21,11 @@ import (
 	"strings"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/cloud"
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/util"
 )
 
 var (

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -24,9 +24,9 @@ import (
 	"net"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/util"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/util"
 )
 
 // Mode is the operating mode of the CSI driver.

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	goexec "os/exec"
 
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/fibrechannel"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
 	"k8s.io/utils/mount"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/fibrechannel"
 )
 
 // Mounter is an interface for mount operations

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -24,13 +24,13 @@ import (
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/cloud"
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/fibrechannel"
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 	mountutils "k8s.io/mount-utils"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/fibrechannel"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/util"
 )
 
 const (

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,5 +1,5 @@
 ## E2E Testing
-E2E test verifies the funcitonality of PowerVS CSI driver in the context of Kubernetes. It exercises driver feature e2e including static provisioning, dynamic provisioning, volume scheduling, mount options, etc.
+E2E test verifies the funcitonality of IBM PowerVS Block CSI Driver in the context of Kubernetes. It exercises driver feature e2e including static provisioning, dynamic provisioning, volume scheduling, mount options, etc.
 
 ### Notes
 Some tests marked with `[env]` require specific environmental variables to be set, if not set these tests will be skipped.

--- a/tests/e2e/driver/powervs_csi_driver.go
+++ b/tests/e2e/driver/powervs_csi_driver.go
@@ -19,11 +19,11 @@ package driver
 import (
 	"fmt"
 
-	powervscsidriver "github.com/ppc64le-cloud/powervs-csi-driver/pkg/driver"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	powervscsidriver "sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/driver"
 )
 
 const (

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -20,14 +20,14 @@ import (
 	"fmt"
 	"os"
 
-	powervscloud "github.com/ppc64le-cloud/powervs-csi-driver/pkg/cloud"
-	powervscsidriver "github.com/ppc64le-cloud/powervs-csi-driver/pkg/driver"
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/testsuites"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	powervscloud "sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud"
+	powervscsidriver "sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/driver"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/testsuites"
 
 	. "github.com/onsi/ginkgo"
 )

--- a/tests/e2e/pre_provisioning.go
+++ b/tests/e2e/pre_provisioning.go
@@ -23,12 +23,12 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	powervscloud "github.com/ppc64le-cloud/powervs-csi-driver/pkg/cloud"
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/testsuites"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	powervscloud "sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/testsuites"
 )
 
 const (

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -71,5 +71,5 @@ func TestE2E(t *testing.T) {
 	}
 	log.Printf("Starting e2e run %q on Ginkgo node %d", uuid.NewUUID(), config.GinkgoConfig.ParallelNode) // TODO use framework.RunID like upstream
 
-	RunSpecsWithDefaultAndCustomReporters(t, "Power VS CSI Driver End-to-End Tests", r)
+	RunSpecsWithDefaultAndCustomReporters(t, "IBM PowerVS Block CSI Driver End-to-End Tests", r)
 }

--- a/tests/e2e/testsuites/dynamically_provisioned_cmd_volume_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_cmd_volume_tester.go
@@ -18,9 +18,9 @@ package testsuites
 
 import (
 	. "github.com/onsi/ginkgo"
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
 )
 
 // DynamicallyProvisionedCmdVolumeTest will provision required StorageClass(es), PVC(s) and Pod(s)

--- a/tests/e2e/testsuites/dynamically_provisioned_collocated_pod_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_collocated_pod_tester.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testsuites
 
 import (
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
 
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"

--- a/tests/e2e/testsuites/dynamically_provisioned_delete_pod_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_delete_pod_tester.go
@@ -18,9 +18,9 @@ package testsuites
 
 import (
 	. "github.com/onsi/ginkgo"
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
 )
 
 // DynamicallyProvisionedDeletePodTest will provision required StorageClass and Deployment

--- a/tests/e2e/testsuites/dynamically_provisioned_read_only_volume_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_read_only_volume_tester.go
@@ -19,9 +19,9 @@ package testsuites
 import (
 	"fmt"
 
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
 
 	clientset "k8s.io/client-go/kubernetes"
 

--- a/tests/e2e/testsuites/dynamically_provisioned_reclaim_policy_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_reclaim_policy_tester.go
@@ -16,8 +16,8 @@ limitations under the License.
 package testsuites
 
 import (
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/cloud"
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
 
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"

--- a/tests/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ppc64le-cloud/powervs-csi-driver/pkg/util"
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/util"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
 
 	. "github.com/onsi/ginkgo"
 	clientset "k8s.io/client-go/kubernetes"

--- a/tests/e2e/testsuites/dynamically_provisioned_topology_aware_volume_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_topology_aware_volume_tester.go
@@ -18,7 +18,7 @@ package testsuites
 import (
 	"fmt"
 
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
 
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"

--- a/tests/e2e/testsuites/pre_provisioned_volume_tester.go
+++ b/tests/e2e/testsuites/pre_provisioned_volume_tester.go
@@ -18,9 +18,9 @@ package testsuites
 
 import (
 	. "github.com/onsi/ginkgo"
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
 )
 
 // PreProvisionedVolumeTest will provision required PV(s), PVC(s) and Pod(s)

--- a/tests/e2e/testsuites/specs.go
+++ b/tests/e2e/testsuites/specs.go
@@ -19,10 +19,10 @@ package testsuites
 import (
 	"fmt"
 
-	"github.com/ppc64le-cloud/powervs-csi-driver/tests/e2e/driver"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
 
 	. "github.com/onsi/ginkgo"
 )

--- a/tests/e2e/testsuites/testsuites.go
+++ b/tests/e2e/testsuites/testsuites.go
@@ -24,7 +24,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	powervscloud "github.com/ppc64le-cloud/powervs-csi-driver/pkg/cloud"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -38,6 +37,7 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
 	imageutils "k8s.io/kubernetes/test/utils/image"
+	powervscloud "sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud"
 )
 
 const (


### PR DESCRIPTION
- Module name changed to sigs.k8s.io/ibm-powervs-block-csi-driver
- Internal names changed from powervs-csi-driver to ibm-powervs-block-csi-driver

**Other fix in Makefile** :

- The Version for the image was hardcoded as `latest` earlier. Now changed as per variable `VERSION`
